### PR TITLE
Fixed: NSString.description is no longer used for the token.

### DIFF
--- a/TPNS_iOS.podspec
+++ b/TPNS_iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name                = 'TPNS_iOS'
-  spec.version             = '1.1.0'
+  spec.version             = '1.1.1'
   spec.license             = 'MIT'
   spec.authors             = { 'Deutsche Telekom AG' => 'tpns@telekom.de' }
   spec.homepage            = 'http://telekom.de'

--- a/TPNS_iOS/DTPushNotification.m
+++ b/TPNS_iOS/DTPushNotification.m
@@ -26,6 +26,9 @@ static NSString *DTPNSUserDefaultsPushToken       = @"DTPNSUserDefaultsPushToken
 
 @end
 
+@interface NSData (tokenExtension)
+- (NSString *) tokenString;
+@end
 
 @implementation DTPushNotification
 @synthesize serverURL = _serverURL;
@@ -196,8 +199,7 @@ static NSString *DTPNSUserDefaultsPushToken       = @"DTPNSUserDefaultsPushToken
     
     self.registrationInProgress = YES;
     
-    NSCharacterSet *trimSet = [NSCharacterSet characterSetWithCharactersInString:@"<>"];
-    NSString *pushTokenString = [[[pushToken description] stringByTrimmingCharactersInSet:trimSet] stringByReplacingOccurrencesOfString:@" " withString:@""];
+    NSString *pushTokenString = [pushToken tokenString];
     
     self.serverURL = url;
     self.appKey = appKey;
@@ -279,6 +281,21 @@ static NSString *DTPNSUserDefaultsPushToken       = @"DTPNSUserDefaultsPushToken
     }];
     
     
+}
+
+@end
+
+@implementation NSData (tokenExtension)
+
+- (NSString *) tokenString {
+    NSMutableString *token = [NSMutableString new];
+    const unsigned char *bytes = self.bytes;
+    NSInteger index = 0;
+
+    for (index = 0; index < self.length; ++index) {
+        [token appendFormat:@"%02lX", (unsigned long)bytes[index]];
+    }
+    return [token lowercaseString];
 }
 
 @end


### PR DESCRIPTION
Since iOS 13, the behaviour of NSString.description changed and no longer produces the expected result